### PR TITLE
Create Kotlin fundamentals with project

### DIFF
--- a/Kotlin(Android)/Kotlin fundamentals with project
+++ b/Kotlin(Android)/Kotlin fundamentals with project
@@ -1,0 +1,11 @@
+//Let's get some hands on kotlin with kotlin playground will add reoureces too here 
+//kotlin dsl
+buildscript {
+    repositories { mavenCentral() }
+
+    dependencies {
+        val kotlinVersion = "1.7.10"
+        classpath(kotlin("gradle-plugin", version = kotlinVersion))
+        classpath(kotlin("serialization", version = kotlinVersion))
+    }
+}


### PR DESCRIPTION
Why is Android development Kotlin-first?
We reviewed feedback that came directly from developers at conferences, our Customer Advisory Board (CAB), Google Developers Experts (GDE), and through our developer research. Many developers already enjoy using Kotlin, and the request for more Kotlin support was clear. Here’s what developers appreciate about writing in Kotlin:

Expressive and concise: You can do more with less. Express your ideas and reduce the amount of boilerplate code. 67% of professional developers who use Kotlin say Kotlin has increased their productivity. Safer code: Kotlin has many language features to help you avoid common programming mistakes such as null pointer exceptions. Android apps that contain Kotlin code are 20% less likely to crash. Interoperable: Call Java-based code from Kotlin, or call Kotlin from Java-based code. Kotlin is 100% interoperable with the Java programming language, so you can have as little or as much of Kotlin in your project as you want. Structured Concurrency: Kotlin coroutines make asynchronous code as easy to work with as blocking code. Coroutines dramatically simplify background task management for everything from network calls to accessing local data. What does Kotlin-first mean?
When building new Android development tools and content, such as Jetpack libraries, samples, documentation, and training content, we will design them with Kotlin users in mind while continuing to provide support for using our APIs from the Java programming language.